### PR TITLE
Enhancement: Standardize Navigation to Desired Pages by Directly Modifying Page URL

### DIFF
--- a/themes/mainroad/assets/css/style.css
+++ b/themes/mainroad/assets/css/style.css
@@ -913,7 +913,14 @@ button:not(:-moz-focusring):focus > .menu__btn-title {
 	color: #000;
 	background: #f5f5f5;
 }
-
+.pagination_to__page input {
+    padding: 0;
+    background: transparent;
+    border: none;
+	font-weight: 700;
+    color: white;
+    width: auto;
+}
 .pagination__item:hover,
 .pagination__item--current {
 	color: #fff;

--- a/themes/mainroad/layouts/partials/pagination.html
+++ b/themes/mainroad/layouts/partials/pagination.html
@@ -1,13 +1,41 @@
 {{- if or (.Paginator.HasPrev) (.Paginator.HasNext) }}
 <div class="pagination">
 	{{- if .Paginator.HasPrev }}
-	<a class="pagination__item pagination__item--prev btn" href="{{ .Paginator.Prev.URL }}">«</a>
+	<a
+		class="pagination__item pagination__item--prev btn"
+		href="{{ .Paginator.Prev.URL }}"
+		>«</a
+	>
 	{{- end }}
-	<span class="pagination__item pagination__item--current">
-		{{- .Paginator.PageNumber }}/{{ .Paginator.TotalPages -}}
+	<span class="pagination__item pagination__item--current pagination_to__page">
+		<form onsubmit="jumpToPage(); return false;" style="display: inline-flex">
+			<input
+				value="{{ .Paginator.PageNumber }}"
+				type="number"
+				id="page-input"
+				min="1"
+				max="{{ .Paginator.TotalPages }}"
+				required
+			/>
+		</form>
+		/{{ .Paginator.TotalPages -}}
 	</span>
 	{{- if .Paginator.HasNext }}
-	<a class="pagination__item pagination__item--next btn" href="{{ .Paginator.Next.URL }}">»</a>
+	<a
+		class="pagination__item pagination__item--next btn"
+		href="{{ .Paginator.Next.URL }}"
+		>»</a
+	>
 	{{- end }}
 </div>
+<script>
+	function jumpToPage() {
+	    var pageInput = document.getElementById("page-input");
+	    var pageNumber = parseInt(pageInput.value);
+	    if (pageNumber >= 1 && pageNumber <= {{ .Paginator.TotalPages }}) {
+	        var targetURL = "{{ .Site.BaseURL }}page/" + pageNumber + "/";
+	        window.location.href = targetURL;
+	    }
+	}
+</script>
 {{- end }}


### PR DESCRIPTION
### Overview

The Linux.cn Archive comprises a total of 207 pages. However, we can efficiently navigate to our desired page by directly modifying the URL to `/page/2/` and onward. Therefore, this pull request introduces a streamlined approach to navigate to the desired page by directly modifying the current page, denoted as `PageNumber`.

https://github.com/Linux-CN/archive/blob/ee56f775fae67f2f2718687842ced42a2b31c36c/themes/mainroad/layouts/partials/pagination.html#L6-L8

```diff
pagination.html ----------------------------------

+		<form onsubmit="jumpToPage(); return false;" style="display: inline-flex">
+			<input
+				value="{{ .Paginator.PageNumber }}"
+				type="number"
+				id="page-input"
+				min="1"
+				max="{{ .Paginator.TotalPages }}"
+				required
+			/>
+		</form>
+		/{{ .Paginator.TotalPages -}}
- {{- .Paginator.PageNumber }}

+<script>
+	function jumpToPage() {
+	    var pageInput = document.getElementById("page-input");
+	    var pageNumber = parseInt(pageInput.value);
+	    if (pageNumber >= 1 && pageNumber <= {{ .Paginator.TotalPages }}) {
+	        var targetURL = "{{ .Site.BaseURL }}page/" + pageNumber + "/";
+	        window.location.href = targetURL;
+	    }
+	}
+</script>

style.css ----------------------------------

+.pagination_to__page input {
+    padding: 0;
+    background: transparent;
+    border: none;
+	font-weight: 700;
+    color: white;
+    width: auto;
+}
```

### Changes

In this pull request, we implement a method to modify the current page number (`PageNumber`) directly, allowing users to easily navigate to the specific page they intend to access.

### How to Use

To navigate to a specific page, simply modify the page number in the URL (e.g., `/page/2/`) to the desired value. This enhancement provides a more user-friendly way to access the desired content within the Linux.cn Archive.

![CleanShot 2024-02-22 at 20 19 44](https://github.com/Linux-CN/archive/assets/57232813/d376a3b1-eb32-4bfd-a437-3a09c0bfd91d)

### Additional Information

- The Linux.cn Archive currently consists of 207 pages.
- This enhancement simplifies the navigation process by allowing direct modification of the page number in the URL.

---
*Some browsers may enhance the input form, for instance, with features like numeric keypad or letter case selection, which could potentially affect the styling. However, it's essential to note that this is merely a demonstration (DEMO) example. Perhaps consider switching to a theme that is more focused on handling a large volume of articles.

